### PR TITLE
improved src/

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -368,8 +368,8 @@ namespace streamulus
 
         Graph mGraph;
         std::set<QueueEntry> mQueue;
-        TimestampT mCurrentTime;
         bool mWorking;    
+        TimestampT mCurrentTime;
         std::vector<StropPtr> mSources;
         bool mVerbose;
         unsigned int mNumRemovedVertices;

--- a/src/transforms.h
+++ b/src/transforms.h
@@ -109,7 +109,7 @@ namespace streamulus
         {  
             if (engine->IsVerbose())
                 std::cout << "generic_func" << std::endl;
-            typedef result<generic_func(F&,State)> Result;
+            //typedef result<generic_func(F&,State)> Result;
             typedef Func0<F> FuncStropType; 
             
             boost::shared_ptr<FuncStropType> funcStropPtr(new FuncStropType(f));                         


### PR DESCRIPTION
silence g++ -Wall -pedantic by
- commenting out one unused variable and
- aligning initialization
