### PR TITLE
make graph file writing optional

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -168,7 +168,9 @@ namespace streamulus
                 
         void StartEngine()
         {
+#if defined(WRITE_GRAPH)
             WriteGraph("TsGraph.vis");
+#endif
             ActivateSources();
             Work();            
         }


### PR DESCRIPTION
we probably want to add a setter that can provide a filename...

this fourth pull-request may be the one you like the least, it is also the smallest  -- I don't think we should leave file behind unconditionally so I made it a compile-time option. We can easily make it run-time too.
